### PR TITLE
feat: add GET /_healthcheck url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ RUN apt update && apt install -y ca-certificates curl && rm -rf /var/lib/apt/lis
 COPY --from=builder /go/src/github.com/numary/search/search /usr/local/bin/search
 EXPOSE 8080
 ENTRYPOINT ["search"]
-CMD ["server"]
+CMD ["serve"]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,11 @@ import (
 	"github.com/spf13/viper"
 )
 
+func init() {
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
+	viper.AutomaticEnv()
+}
+
 var (
 	Version   = "develop"
 	BuildDate = "-"
@@ -35,9 +40,6 @@ func NewRootCommand() *cobra.Command {
 	root.AddCommand(server)
 
 	root.Flags().Bool(debugFlag, false, "debug mode")
-
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
-	viper.AutomaticEnv()
 	err := viper.BindPFlags(root.Flags())
 	if err != nil {
 		panic(err)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,9 +41,8 @@ services:
     depends_on:
     - opensearch
   search:
-    command: go run main.go
-    build:
-      target: dev
+    command: go run main.go serve
+    image: golang:1.18-alpine
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://127.0.0.1:8080/_healthcheck" ]
       interval: 10s
@@ -63,3 +62,4 @@ services:
       OTEL_TRACES_EXPORTER_OTLP_INSECURE: "true"
     volumes:
       - .:/app
+    working_dir: /app

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,12 @@ go 1.18
 require (
 	github.com/aquasecurity/esquery v0.2.0
 	github.com/bombsimon/logrusr/v3 v3.0.0
+	github.com/davecgh/go-spew v1.1.1
 	github.com/elastic/go-elasticsearch/v7 v7.17.1
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
-	github.com/numary/go-libs v0.0.0-20220614122310-19e6f94d07c3
+	github.com/numary/go-libs v0.0.0-20220801155717-200c269e800d
+	github.com/numary/go-libs/sharedhealth v0.0.0-20220801152411-b600be8e0d85
 	github.com/numary/ledger v1.0.0-rc1
 	github.com/opensearch-project/opensearch-go v1.1.0
 	github.com/ory/dockertest/v3 v3.8.1
@@ -30,7 +32,6 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/containerd/continuity v0.3.0 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgraph-io/ristretto v0.1.0 // indirect
 	github.com/docker/cli v20.10.16+incompatible // indirect
 	github.com/docker/docker v20.10.16+incompatible // indirect
@@ -55,6 +56,7 @@ require (
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
+	github.com/numary/go-libs/sharedotlp v0.0.0-20220801155717-200c269e800d // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opencontainers/runc v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -620,8 +620,14 @@ github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/numary/go-libs v0.0.0-20220614122310-19e6f94d07c3 h1:efaq9m7swyS/Hl9xS34B2oS926kO9oFHy3nTYiFuwDg=
-github.com/numary/go-libs v0.0.0-20220614122310-19e6f94d07c3/go.mod h1:7StJNTZ3QbU2uBWpOeryPaHD6xMYUN8AWXWTjP67kv0=
+github.com/numary/go-libs v0.0.0-20220801152411-b600be8e0d85 h1:4Fw7M+JcomfAu+YmSuIRpQA5qP7GbBCuh+Fc+gHQQ9A=
+github.com/numary/go-libs v0.0.0-20220801152411-b600be8e0d85/go.mod h1:mZQ9h1F6w+3hN3xgfEElJjR2SWLn/ZCWGi67CmQaRkQ=
+github.com/numary/go-libs v0.0.0-20220801155717-200c269e800d h1:XbDELISHgFsIkV6T1NM36MRjPU/k5mTZpVbKSwpSG/w=
+github.com/numary/go-libs v0.0.0-20220801155717-200c269e800d/go.mod h1:Jsfy6yKwxVaBFFuFL9IVYbMKvepElGQYVoWMhFdK0l0=
+github.com/numary/go-libs/sharedhealth v0.0.0-20220801152411-b600be8e0d85 h1:+KA84QMomrNaoHrtrDIRbE4HkUrgu3JAsXcw8XF3OGQ=
+github.com/numary/go-libs/sharedhealth v0.0.0-20220801152411-b600be8e0d85/go.mod h1:DzBUp4HCdWscgXmt8/5F/KlCSktv0OwgOwDfRdz5Hzo=
+github.com/numary/go-libs/sharedotlp v0.0.0-20220801155717-200c269e800d h1:RPL0L1fFBc1tOO1DQxvQO5Cqx8Nm8U9GmGNGkhvEZus=
+github.com/numary/go-libs/sharedotlp v0.0.0-20220801155717-200c269e800d/go.mod h1:AZTmSrMGpNL9GzacAKwYsbSs+1U2ItR9i074hNILq6o=
 github.com/numary/ledger v0.0.0-20210702172952-a5bd30e551d0/go.mod h1:u2K28z9TDYd6id1qeD2uv7JDlajuRZ0fvOnCeDZmDxk=
 github.com/numary/ledger v0.0.0-20211227131550-dc7b78f85b5b/go.mod h1:uovuDsK7Gs7duqKQ9PgaFulJnPTDftGdR/n3rBRzNIs=
 github.com/numary/ledger v1.0.0-rc1 h1:HB1TYCWUvEMuYfWxPbsFt+UZ03MX94H6wUAhnoRkiDw=


### PR DESCRIPTION
# Add health checks

This PR use the github.com/numary/go-libs/sharedhealth module to provide a /_healthcheck endpoint.
Currently there are only one check : the elasticsearch/opensearch connection.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Technical debt
